### PR TITLE
Fix security issues #24-#28: ownership, sandbox, CSP, symlinks, sanitizer

### DIFF
--- a/AspireOllama.ApiService/Endpoints/ChatEndpoint.cs
+++ b/AspireOllama.ApiService/Endpoints/ChatEndpoint.cs
@@ -46,8 +46,8 @@ public class ChatEndpoint(
             await messageService.AddAsync(req.SessionId, "user", historyContent, req.Images, req.Files);
             await messageService.AddAsync(req.SessionId, "assistant", result.Response);
 
-            await UpdateSessionTitleIfFirstMessage(req);
-            await sessionService.TouchAsync(req.SessionId);
+            await UpdateSessionTitleIfFirstMessage(req, userId);
+            await sessionService.TouchAsync(req.SessionId, userId);
 
             logger.LogInformation("Chat complete, {ToolCount} tool calls", result.ToolCalls.Count);
 
@@ -93,7 +93,7 @@ public class ChatEndpoint(
         return content;
     }
 
-    private async Task UpdateSessionTitleIfFirstMessage(ChatMessageRequest req)
+    private async Task UpdateSessionTitleIfFirstMessage(ChatMessageRequest req, string userId)
     {
         var messageCount = await messageService.GetCountAsync(req.SessionId);
 
@@ -105,7 +105,7 @@ public class ChatEndpoint(
                    ?? req.Images?.FirstOrDefault()?.FileName
                    ?? "New Chat");
 
-            await sessionService.UpdateTitleAsync(req.SessionId, title);
+            await sessionService.UpdateTitleAsync(req.SessionId, userId, title);
         }
     }
 }

--- a/AspireOllama.ApiService/Services/Session/ISessionService.cs
+++ b/AspireOllama.ApiService/Services/Session/ISessionService.cs
@@ -6,8 +6,8 @@ public interface ISessionService
 {
     Task<ChatSession> CreateAsync(string userId, string userName);
     Task<List<ChatSession>> GetAllAsync(string userId);
-    Task<ChatSessionDetails?> GetByIdAsync(string sessionId, string? userId = null);
-    Task<bool> DeleteAsync(string sessionId, string? userId = null);
-    Task UpdateTitleAsync(string sessionId, string title);
-    Task TouchAsync(string sessionId);
+    Task<ChatSessionDetails?> GetByIdAsync(string sessionId, string userId);
+    Task<bool> DeleteAsync(string sessionId, string userId);
+    Task UpdateTitleAsync(string sessionId, string userId, string title);
+    Task TouchAsync(string sessionId, string userId);
 }

--- a/AspireOllama.ApiService/Services/Session/SessionService.cs
+++ b/AspireOllama.ApiService/Services/Session/SessionService.cs
@@ -32,10 +32,10 @@ public class SessionService(MongoCollections collections) : ISessionService
         return sessions.Select(ToDto).ToList();
     }
 
-    public async Task<ChatSessionDetails?> GetByIdAsync(string sessionId, string? userId = null)
+    public async Task<ChatSessionDetails?> GetByIdAsync(string sessionId, string userId)
     {
         var session = await collections.Sessions
-            .Find(s => s.Id == sessionId && (userId == null || s.UserId == userId))
+            .Find(s => s.Id == sessionId && s.UserId == userId)
             .FirstOrDefaultAsync();
 
         if (session is null)
@@ -56,9 +56,9 @@ public class SessionService(MongoCollections collections) : ISessionService
         };
     }
 
-    public async Task<bool> DeleteAsync(string sessionId, string? userId = null)
+    public async Task<bool> DeleteAsync(string sessionId, string userId)
     {
-        var result = await collections.Sessions.DeleteOneAsync(s => s.Id == sessionId && (userId == null || s.UserId == userId));
+        var result = await collections.Sessions.DeleteOneAsync(s => s.Id == sessionId && s.UserId == userId);
         if (result.DeletedCount == 0)
             return false;
 
@@ -66,18 +66,18 @@ public class SessionService(MongoCollections collections) : ISessionService
         return true;
     }
 
-    public async Task UpdateTitleAsync(string sessionId, string title)
+    public async Task UpdateTitleAsync(string sessionId, string userId, string title)
     {
         var truncated = title.Length > 50 ? title[..47] + "..." : title;
         await collections.Sessions.UpdateOneAsync(
-            s => s.Id == sessionId,
+            s => s.Id == sessionId && s.UserId == userId,
             Builders<ChatSessionDocument>.Update.Set(s => s.Title, truncated));
     }
 
-    public async Task TouchAsync(string sessionId)
+    public async Task TouchAsync(string sessionId, string userId)
     {
         await collections.Sessions.UpdateOneAsync(
-            s => s.Id == sessionId,
+            s => s.Id == sessionId && s.UserId == userId,
             Builders<ChatSessionDocument>.Update.Set(s => s.UpdatedAt, DateTime.UtcNow));
     }
 

--- a/AspireOllama.ApiService/Services/Tools/CodeExecutionTool.cs
+++ b/AspireOllama.ApiService/Services/Tools/CodeExecutionTool.cs
@@ -106,11 +106,14 @@ public class CodeExecutionTool : ITool
     private static readonly HashSet<string> BlockedTypes = new(StringComparer.OrdinalIgnoreCase)
     {
         "File", "Directory", "Path", "FileInfo", "DirectoryInfo", "FileStream",
-        "StreamReader", "StreamWriter", "Process", "ProcessStartInfo",
+        "StreamReader", "StreamWriter", "TextReader", "TextWriter",
+        "Process", "ProcessStartInfo",
         "Environment", "Assembly", "Type", "Activator", "Marshal",
         "HttpClient", "HttpWebRequest", "WebClient", "WebRequest",
         "Socket", "TcpClient", "UdpClient", "TcpListener",
-        "RegistryKey", "Registry", "AppDomain", "GC"
+        "RegistryKey", "Registry", "AppDomain", "GC",
+        "Console", "Dns", "XDocument", "XmlDocument",
+        "ServicePointManager", "ConfigurationManager"
     };
 
     private static string? ValidateCodeSafety(string code)
@@ -128,7 +131,11 @@ public class CodeExecutionTool : ITool
                 return "Stack allocation is not allowed.";
         }
 
-        // Check all identifiers and qualified names against blocklists
+        // Block 'dynamic' type usage (enables reflection bypass)
+        if (root.DescendantNodes().OfType<IdentifierNameSyntax>().Any(id => id.Identifier.Text == "dynamic"))
+            return "Dynamic typing is not allowed.";
+
+        // Check all identifiers, qualified names, and typeof expressions against blocklists
         foreach (var node in root.DescendantNodes())
         {
             var name = node switch
@@ -151,6 +158,32 @@ public class CodeExecutionTool : ITool
             // Check if any blocked type is used as an identifier
             if (node is IdentifierNameSyntax identNode && BlockedTypes.Contains(identNode.Identifier.Text))
                 return $"Access to type '{identNode.Identifier.Text}' is not allowed.";
+
+            // Block typeof() expressions that reference blocked types/namespaces
+            if (node is TypeOfExpressionSyntax typeOfExpr)
+            {
+                var typeName = typeOfExpr.Type.ToString();
+                foreach (var ns in BlockedNamespaces)
+                {
+                    if (typeName.Contains(ns, StringComparison.OrdinalIgnoreCase))
+                        return $"typeof() access to '{ns}' is not allowed.";
+                }
+                // Check the leaf type name
+                var leafType = typeName.Split('.').Last();
+                if (BlockedTypes.Contains(leafType))
+                    return $"typeof() access to '{leafType}' is not allowed.";
+            }
+
+            // Block string literals containing blocked namespace names (defense-in-depth against reflection)
+            if (node is LiteralExpressionSyntax literal && literal.IsKind(SyntaxKind.StringLiteralExpression))
+            {
+                var value = literal.Token.ValueText;
+                foreach (var ns in BlockedNamespaces)
+                {
+                    if (value.Contains(ns, StringComparison.OrdinalIgnoreCase))
+                        return $"String literals referencing '{ns}' are not allowed.";
+                }
+            }
         }
 
         return null;

--- a/AspireOllama.ApiService/Services/Tools/FileOperationsTool.cs
+++ b/AspireOllama.ApiService/Services/Tools/FileOperationsTool.cs
@@ -200,6 +200,13 @@ public class FileOperationsTool : ITool
             throw new UnauthorizedAccessException("Access denied: Path is outside sandbox.");
         }
 
+        // Reject symlinks and junctions to prevent sandbox escape
+        if ((File.Exists(fullPath) || System.IO.Directory.Exists(fullPath)) &&
+            File.GetAttributes(fullPath).HasFlag(FileAttributes.ReparsePoint))
+        {
+            throw new UnauthorizedAccessException("Access denied: Symlinks are not allowed in sandbox.");
+        }
+
         return fullPath;
     }
 }

--- a/AspireOllama.Web/Components/App.razor
+++ b/AspireOllama.Web/Components/App.razor
@@ -15,12 +15,7 @@
 
 <body style="margin:0;background:#0a0a0f;">
     <Routes />
-    <script>
-        window.scrollChatToBottom = function() {
-            var el = document.querySelector('.messages-area');
-            if (el) el.scrollTop = el.scrollHeight;
-        };
-    </script>
+    <script src="js/chat.js"></script>
     <script src="@Assets["_framework/blazor.web.js"]"></script>
 </body>
 

--- a/AspireOllama.Web/Components/Pages/Agents.razor
+++ b/AspireOllama.Web/Components/Pages/Agents.razor
@@ -1907,7 +1907,25 @@
         return new MarkupString(svg);
     }
 
-    private static readonly Ganss.Xss.HtmlSanitizer Sanitizer = new();
+    private static readonly Ganss.Xss.HtmlSanitizer Sanitizer = CreateSanitizer();
+
+    private static Ganss.Xss.HtmlSanitizer CreateSanitizer()
+    {
+        var sanitizer = new Ganss.Xss.HtmlSanitizer();
+        sanitizer.AllowedSchemes.Clear();
+        sanitizer.AllowedSchemes.Add("https");
+        sanitizer.AllowedSchemes.Add("http");
+        sanitizer.AllowedSchemes.Add("mailto");
+        sanitizer.PostProcessNode += (_, e) =>
+        {
+            if (e.Node is AngleSharp.Html.Dom.IHtmlAnchorElement anchor)
+            {
+                anchor.SetAttribute("rel", "noopener noreferrer");
+                anchor.SetAttribute("target", "_blank");
+            }
+        };
+        return sanitizer;
+    }
 
     private static string RenderMarkdown(string? markdown)
     {

--- a/AspireOllama.Web/Components/Pages/Chat.razor
+++ b/AspireOllama.Web/Components/Pages/Chat.razor
@@ -1789,7 +1789,25 @@
     // ============================================================
 
     private static readonly Markdig.MarkdownPipeline MarkdownPipeline = new Markdig.MarkdownPipelineBuilder().Build();
-    private static readonly Ganss.Xss.HtmlSanitizer Sanitizer = new();
+    private static readonly Ganss.Xss.HtmlSanitizer Sanitizer = CreateSanitizer();
+
+    private static Ganss.Xss.HtmlSanitizer CreateSanitizer()
+    {
+        var sanitizer = new Ganss.Xss.HtmlSanitizer();
+        sanitizer.AllowedSchemes.Clear();
+        sanitizer.AllowedSchemes.Add("https");
+        sanitizer.AllowedSchemes.Add("http");
+        sanitizer.AllowedSchemes.Add("mailto");
+        sanitizer.PostProcessNode += (_, e) =>
+        {
+            if (e.Node is AngleSharp.Html.Dom.IHtmlAnchorElement anchor)
+            {
+                anchor.SetAttribute("rel", "noopener noreferrer");
+                anchor.SetAttribute("target", "_blank");
+            }
+        };
+        return sanitizer;
+    }
 
     private static string RenderMarkdown(string markdown) =>
         Sanitizer.Sanitize(Markdig.Markdown.ToHtml(markdown, MarkdownPipeline));

--- a/AspireOllama.Web/Program.cs
+++ b/AspireOllama.Web/Program.cs
@@ -91,7 +91,7 @@ app.UseHttpsRedirection();
 app.Use(async (context, next) =>
 {
     context.Response.Headers["Content-Security-Policy"] =
-        "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;";
+        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:;";
     context.Response.Headers["X-Content-Type-Options"] = "nosniff";
     context.Response.Headers["X-Frame-Options"] = "DENY";
     await next();

--- a/AspireOllama.Web/wwwroot/js/chat.js
+++ b/AspireOllama.Web/wwwroot/js/chat.js
@@ -1,0 +1,4 @@
+window.scrollChatToBottom = function () {
+    var el = document.querySelector('.messages-area');
+    if (el) el.scrollTop = el.scrollHeight;
+};


### PR DESCRIPTION
## Summary
- Fixes 5 open security issues: 2 critical, 2 high, 1 medium
- Build: 0 warnings, 0 errors

### #24 CRITICAL — Session ownership check hardened
- `userId` is now **required** (non-nullable) on `GetByIdAsync` and `DeleteAsync`
- Added `userId` ownership filter to `UpdateTitleAsync` and `TouchAsync`
- Eliminates the fragile optional parameter that could bypass ownership if omitted

### #25 CRITICAL — CodeExecutionTool sandbox escape prevention
- Block `dynamic` keyword (prevents reflection-based bypass)
- Block `typeof()` expressions referencing blocked types/namespaces
- Block string literals containing blocked namespace names (defense-in-depth)
- Added missing blocked types: `Console`, `Dns`, `XDocument`, `XmlDocument`, `ServicePointManager`, `ConfigurationManager`, `TextReader`, `TextWriter`

### #26 HIGH — CSP unsafe-inline removed
- Moved inline `scrollChatToBottom` to external `wwwroot/js/chat.js`
- Removed `'unsafe-inline'` from `script-src` CSP directive
- CSP now properly blocks inline script execution

### #27 HIGH — Symlink/junction sandbox escape prevention
- Added `FileAttributes.ReparsePoint` check on resolved paths in `GetSafePath`
- Rejects symlinks and NTFS junctions inside the sandbox directory

### #28 MEDIUM — HtmlSanitizer phishing link protection
- Restricted URL schemes to `https`, `http`, `mailto` only (blocks `javascript:`, `data:`, `vbscript:`)
- Added `rel="noopener noreferrer"` and `target="_blank"` to all rendered links
- Applied to both Chat.razor and Agents.razor sanitizers

## Test plan
- [ ] Build succeeds with 0 warnings, 0 errors
- [ ] `SessionService.GetByIdAsync(id, userId)` requires userId — no optional bypass
- [ ] `UpdateTitleAsync` and `TouchAsync` filter by userId
- [ ] CodeExecutionTool blocks `dynamic x = ...` expressions
- [ ] CodeExecutionTool blocks `typeof(int).Assembly` reflection paths
- [ ] CodeExecutionTool blocks string literals like `"System.IO.File"`
- [ ] CSP header has no `unsafe-inline` in script-src
- [ ] `scrollChatToBottom` works from external JS file
- [ ] Symlinks inside sandbox are rejected with UnauthorizedAccessException
- [ ] Rendered markdown links use `rel="noopener noreferrer"` and `target="_blank"`
- [ ] `javascript:` scheme links are stripped by sanitizer

🤖 Generated with [Claude Code](https://claude.com/claude-code)